### PR TITLE
Add macro key support (P1-P6) for HP Omen laptops

### DIFF
--- a/src/hp-wmi.c
+++ b/src/hp-wmi.c
@@ -22,6 +22,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/input.h>
+#include <linux/input-event-codes.h>
 #include <linux/input/sparse-keymap.h>
 #include <linux/platform_device.h>
 #include <linux/platform_profile.h>
@@ -182,6 +183,8 @@ struct victus_gpu_power_modes {
 
 enum hp_wmi_gm_commandtype {
 	HPWMI_FAN_SPEED_GET_QUERY		= 0x11,
+	HPWMI_MACRO_PROFILE_SET			= 0x0F,
+	HPWMI_MACRO_MODE_SET			= 0x17,
 	HPWMI_SET_PERFORMANCE_MODE		= 0x1A,
 	HPWMI_FAN_SPEED_MAX_GET_QUERY		= 0x26,
 	HPWMI_FAN_SPEED_MAX_SET_QUERY		= 0x27,
@@ -2210,6 +2213,75 @@ static int thermal_profile_setup(struct platform_device *device)
 	return 0;
 }
 
+/*
+ * Macro key support for HP Omen P1-P6 keys
+ */
+
+#define MACRO_KEY_RELEASE 0x80
+
+static u8 macro_profile_bytes[4096] = {
+	/* P1 */	0x03, KEY_KP1, KEY_KP1 | MACRO_KEY_RELEASE,
+	/* P2 */	0x03, KEY_KP2, KEY_KP2 | MACRO_KEY_RELEASE,
+	/* P3 */	0x03, KEY_KP3, KEY_KP3 | MACRO_KEY_RELEASE,
+	/* P4 */	0x03, KEY_KP4, KEY_KP4 | MACRO_KEY_RELEASE,
+	/* P5 */	0x03, KEY_KP5, KEY_KP5 | MACRO_KEY_RELEASE,
+	/* P6 */	0x03, KEY_KP6, KEY_KP6 | MACRO_KEY_RELEASE,
+
+	/* Ctrl+P1 */	0x05, KEY_LEFTCTRL, KEY_KP1, KEY_KP1 | MACRO_KEY_RELEASE, KEY_LEFTCTRL | MACRO_KEY_RELEASE,
+	/* Ctrl+P2 */	0x05, KEY_LEFTCTRL, KEY_KP2, KEY_KP2 | MACRO_KEY_RELEASE, KEY_LEFTCTRL | MACRO_KEY_RELEASE,
+	/* Ctrl+P3 */	0x05, KEY_LEFTCTRL, KEY_KP3, KEY_KP3 | MACRO_KEY_RELEASE, KEY_LEFTCTRL | MACRO_KEY_RELEASE,
+	/* Ctrl+P4 */	0x05, KEY_LEFTCTRL, KEY_KP4, KEY_KP4 | MACRO_KEY_RELEASE, KEY_LEFTCTRL | MACRO_KEY_RELEASE,
+	/* Ctrl+P5 */	0x05, KEY_LEFTCTRL, KEY_KP5, KEY_KP5 | MACRO_KEY_RELEASE, KEY_LEFTCTRL | MACRO_KEY_RELEASE,
+	/* Ctrl+P6 */	0x05, KEY_LEFTCTRL, KEY_KP6, KEY_KP6 | MACRO_KEY_RELEASE, KEY_LEFTCTRL | MACRO_KEY_RELEASE,
+
+	/* Alt+P1 */	0x05, KEY_LEFTALT, KEY_KP1, KEY_KP1 | MACRO_KEY_RELEASE, KEY_LEFTALT | MACRO_KEY_RELEASE,
+	/* Alt+P2 */	0x05, KEY_LEFTALT, KEY_KP2, KEY_KP2 | MACRO_KEY_RELEASE, KEY_LEFTALT | MACRO_KEY_RELEASE,
+	/* Alt+P3 */	0x05, KEY_LEFTALT, KEY_KP3, KEY_KP3 | MACRO_KEY_RELEASE, KEY_LEFTALT | MACRO_KEY_RELEASE,
+	/* Alt+P4 */	0x05, KEY_LEFTALT, KEY_KP4, KEY_KP4 | MACRO_KEY_RELEASE, KEY_LEFTALT | MACRO_KEY_RELEASE,
+	/* Alt+P5 */	0x05, KEY_LEFTALT, KEY_KP5, KEY_KP5 | MACRO_KEY_RELEASE, KEY_LEFTALT | MACRO_KEY_RELEASE,
+	/* Alt+P6 */	0x05, KEY_LEFTALT, KEY_KP6, KEY_KP6 | MACRO_KEY_RELEASE, KEY_LEFTALT | MACRO_KEY_RELEASE,
+
+	/* Shift+P1 */	0x05, KEY_LEFTSHIFT, KEY_KP1, KEY_KP1 | MACRO_KEY_RELEASE, KEY_LEFTSHIFT | MACRO_KEY_RELEASE,
+	/* Shift+P2 */	0x05, KEY_LEFTSHIFT, KEY_KP2, KEY_KP2 | MACRO_KEY_RELEASE, KEY_LEFTSHIFT | MACRO_KEY_RELEASE,
+	/* Shift+P3 */	0x05, KEY_LEFTSHIFT, KEY_KP3, KEY_KP3 | MACRO_KEY_RELEASE, KEY_LEFTSHIFT | MACRO_KEY_RELEASE,
+	/* Shift+P4 */	0x05, KEY_LEFTSHIFT, KEY_KP4, KEY_KP4 | MACRO_KEY_RELEASE, KEY_LEFTSHIFT | MACRO_KEY_RELEASE,
+	/* Shift+P5 */	0x05, KEY_LEFTSHIFT, KEY_KP5, KEY_KP5 | MACRO_KEY_RELEASE, KEY_LEFTSHIFT | MACRO_KEY_RELEASE,
+	/* Shift+P6 */	0x05, KEY_LEFTSHIFT, KEY_KP6, KEY_KP6 | MACRO_KEY_RELEASE, KEY_LEFTSHIFT | MACRO_KEY_RELEASE,
+
+	/* Fn+P1 */	0x03, KEY_KP7, KEY_KP7 | MACRO_KEY_RELEASE,
+	/* Fn+P2 */	0x03, KEY_KP8, KEY_KP8 | MACRO_KEY_RELEASE,
+	/* Fn+P3 */	0x03, KEY_KP9, KEY_KP9 | MACRO_KEY_RELEASE,
+	/* Fn+P4 */	0x03, KEY_KP0, KEY_KP0 | MACRO_KEY_RELEASE,
+	/* Fn+P5 */	0x03, KEY_KPMINUS, KEY_KPMINUS | MACRO_KEY_RELEASE,
+	/* Fn+P6 */	0x03, KEY_KPPLUS, KEY_KPPLUS | MACRO_KEY_RELEASE,
+};
+
+static int macro_key_setup(struct platform_device *dev)
+{
+	int ret;
+	u32 macro_enable = 1;
+
+	ret = hp_wmi_perform_query(HPWMI_MACRO_PROFILE_SET, HPWMI_GM,
+				   macro_profile_bytes, sizeof(macro_profile_bytes), 0);
+	pr_debug("macro key setup ret 0x%x\n", ret);
+
+	ret = hp_wmi_perform_query(HPWMI_MACRO_MODE_SET, HPWMI_GM,
+				   &macro_enable, sizeof(macro_enable), 0);
+	pr_debug("macro key enable ret 0x%x\n", ret);
+
+	return 0;
+}
+
+static void macro_key_remove(struct platform_device *dev)
+{
+	int ret;
+	u32 macro_disable = 0;
+
+	ret = hp_wmi_perform_query(HPWMI_MACRO_MODE_SET, HPWMI_GM,
+				   &macro_disable, sizeof(macro_disable), 0);
+	pr_debug("macro key disable ret 0x%x\n", ret);
+}
+
 static int hp_wmi_hwmon_init(void);
 
 static int __init hp_wmi_bios_setup(struct platform_device *device)
@@ -2241,6 +2313,8 @@ static int __init hp_wmi_bios_setup(struct platform_device *device)
 
 	thermal_profile_setup(device);
 
+	macro_key_setup(device);
+
 	return 0;
 }
 
@@ -2265,6 +2339,8 @@ static void __exit hp_wmi_bios_remove(struct platform_device *device)
 		rfkill_unregister(wwan_rfkill);
 		rfkill_destroy(wwan_rfkill);
 	}
+
+	macro_key_remove(device);
 }
 
 static int hp_wmi_resume_handler(struct device *device)


### PR DESCRIPTION
## Summary

This PR adds support for the P1-P6 programmable macro keys found on HP Omen gaming laptops.

### Changes
- Add `HPWMI_MACRO_PROFILE_SET` (0x0F) and `HPWMI_MACRO_MODE_SET` (0x17) WMI commands
- Add `macro_profile_bytes` array that maps P1-P6 keys to numpad 1-6 (KP1-KP6)
- Add `macro_key_setup()` and `macro_key_remove()` functions
- Integrate into `hp_wmi_bios_setup()` and `hp_wmi_bios_remove()`

## Key Mapping

| Key | Default | Ctrl+ | Alt+ | Shift+ | Fn+ |
|-----|---------|-------|------|--------|-----|
| P1 | KP1 | Ctrl+KP1 | Alt+KP1 | Shift+KP1 | KP7 |
| P2 | KP2 | Ctrl+KP2 | Alt+KP2 | Shift+KP2 | KP8 |
| P3 | KP3 | Ctrl+KP3 | Alt+KP3 | Shift+KP3 | KP9 |
| P4 | KP4 | Ctrl+KP4 | Alt+KP4 | Shift+KP4 | KP0 |
| P5 | KP5 | Ctrl+KP5 | Alt+KP5 | Shift+KP5 | KP- |
| P6 | KP6 | Ctrl+KP6 | Alt+KP6 | Shift+KP6 | KP+ |

Users can remap these keys using `keyd`, `xbindkeys`, or DE shortcuts.

## Testing

- **Hardware**: HP OMEN Laptop 17-ck0xxx (i9 + RTX 3080)
- **OS**: ZorinOS (Ubuntu 24.04)
- **Kernel**: 6.14.0-37-generic

All 6 macro keys work correctly.

## Credits

Based on [xddxdd/hp-omen-linux-module](https://github.com/xddxdd/hp-omen-linux-module) macro key implementation, ported to kernel 6.14+ API.